### PR TITLE
Auto-calc frame count from canvas size

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,12 @@ this.config = {
   GAP: 10,               // Gap between frames
   DAMPING: 0.9,          // Physics damping factor
   SPRING_STRENGTH: 0.2,  // Spring force strength
-  NUM_FRAMES: 10,        // Number of nested frames
+  HANDLE_SIZE: 40,       // Size of the draggable square
 };
 ```
+
+The number of nested frames is calculated automatically based on the canvas
+size, the frame thickness, the gap and the handle size.
 
 ## 🚀 Deployment
 

--- a/src/game/FramePusher.js
+++ b/src/game/FramePusher.js
@@ -18,9 +18,10 @@ export class FramePusher {
     this.config = {
       FRAME_THICKNESS: 20,
       GAP: 10,
+      HANDLE_SIZE: 40,
       DAMPING: 0.9,
       SPRING_STRENGTH: 0.2,
-      NUM_FRAMES: 10,
+      NUM_FRAMES: 0, // will be calculated
     };
 
     // Game state
@@ -107,6 +108,22 @@ export class FramePusher {
   }
 
   /**
+   * Calculates how many frames can fit in the current canvas
+   * based on thickness, gap and handle size
+   * @private
+   */
+  _calculateNumFrames() {
+    const stepDown = (this.config.GAP + this.config.FRAME_THICKNESS) * 2;
+    if (stepDown <= 0) {
+      return 1;
+    }
+
+    const available = this.canvas.width - this.config.HANDLE_SIZE;
+    const count = Math.floor(available / stepDown);
+    return Math.max(1, count + 1); // include the handle frame
+  }
+
+  /**
    * Creates the nested frame structure
    * @private
    */
@@ -114,9 +131,13 @@ export class FramePusher {
     this.frames = [];
     const stepDown = (this.config.GAP + this.config.FRAME_THICKNESS) * 2;
 
+    this.config.NUM_FRAMES = this._calculateNumFrames();
+
     for (let i = 0; i < this.config.NUM_FRAMES; i++) {
       const isLastFrame = i === this.config.NUM_FRAMES - 1;
-      const size = isLastFrame ? 40 : this.canvas.width - i * stepDown;
+      const size = isLastFrame
+        ? this.config.HANDLE_SIZE
+        : this.canvas.width - i * stepDown;
       const position = (this.canvas.width - size) / 2;
 
       this.frames.push({

--- a/src/game/TweakpaneConfig.js
+++ b/src/game/TweakpaneConfig.js
@@ -18,7 +18,6 @@ export class TweakpaneConfig {
 
     // Configuration parameters
     this.params = {
-      numFrames: game.config.NUM_FRAMES,
       frameThickness: game.config.FRAME_THICKNESS,
       gap: game.config.GAP,
     };
@@ -31,18 +30,6 @@ export class TweakpaneConfig {
    * @private
    */
   _setupControls() {
-    // Number of frames
-    this.pane
-      .addBinding(this.params, "numFrames", {
-        label: "Frames",
-        min: 5,
-        max: 50,
-        step: 1,
-      })
-      .on("change", (ev) =>
-        this._debouncedUpdate("NUM_FRAMES", ev.value, true)
-      );
-
     // Frame thickness
     this.pane
       .addBinding(this.params, "frameThickness", {
@@ -123,7 +110,6 @@ export class TweakpaneConfig {
    */
   _resetToDefaults() {
     const defaults = {
-      numFrames: 10,
       frameThickness: 20,
       gap: 10,
       damping: 0.9,
@@ -135,7 +121,6 @@ export class TweakpaneConfig {
 
     // Batch update configuration
     this.game.updateConfig({
-      NUM_FRAMES: defaults.numFrames,
       FRAME_THICKNESS: defaults.frameThickness,
       GAP: defaults.gap,
     });


### PR DESCRIPTION
## Summary
- compute number of frames automatically based on canvas size, gap and thickness
- drop tweakpane control for frame count
- document new handle size option

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687286dc9c1c83318fa03f8dd5598c2d